### PR TITLE
Feat: Add Google Colab userdata support for ngrok token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 app_output.log
+.ngrok_authtoken

--- a/app.py
+++ b/app.py
@@ -95,13 +95,56 @@ def get_file_details_endpoint(relative_path):
     response, status_code = get_file_details(relative_path)
     return jsonify(response), status_code
 
+# Check if running in Google Colab and try to import userdata
+try:
+    from google.colab import userdata
+    IS_COLAB = True
+except ImportError:
+    IS_COLAB = False
+
 if __name__ == '__main__':
     # --- ngrok Tunnel Setup ---
-    # The NGROK_AUTHTOKEN should be set as an environment variable
-    # for security reasons, not hardcoded here.
-    ngrok_authtoken = os.environ.get("NGROK_AUTHTOKEN")
+    ngrok_authtoken = None
+
+    # 1. (Colab-specific) Try to get the token from Colab's userdata
+    if IS_COLAB:
+        print("INFO: Running in Google Colab. Checking for NGROK_AUTHTOKEN in Colab secrets.")
+        try:
+            ngrok_authtoken = userdata.get('NGROK_AUTHTOKEN')
+            if ngrok_authtoken:
+                print("INFO: Found ngrok token in Colab secrets.")
+        except Exception as e:
+            print(f"INFO: Could not retrieve token from Colab secrets: {e}")
+
+
+    # 2. If not found in Colab, try environment variable
+    if not ngrok_authtoken:
+        print("INFO: Checking for NGROK_AUTHTOKEN environment variable.")
+        ngrok_authtoken = os.environ.get("NGROK_AUTHTOKEN")
+        if ngrok_authtoken:
+            print("INFO: Found ngrok token in environment variables.")
+
+
+    # 3. If not found in env, try to read from a file
+    if not ngrok_authtoken:
+        print("INFO: Checking for .ngrok_authtoken file.")
+        try:
+            with open(".ngrok_authtoken", "r") as f:
+                ngrok_authtoken = f.read().strip()
+            if ngrok_authtoken:
+                print("INFO: Found ngrok token in .ngrok_authtoken file.")
+        except FileNotFoundError:
+            pass # This is an expected case
+        except Exception as e:
+            print(f"ERROR: Could not read .ngrok_authtoken file: {e}")
+
+    # Set the token if it was found by any method
     if ngrok_authtoken:
+        print("INFO: Setting ngrok authtoken.")
         ngrok.set_auth_token(ngrok_authtoken)
+    else:
+        print("WARNING: ngrok authtoken not found. The tunnel will be temporary. Sign up at https://ngrok.com/signup to get a free token.")
+
 
     # Create the audio library directory if it doesn't exist
     if not os.path.exists(AUDIO_LIBRARY_PATH):
@@ -110,12 +153,21 @@ if __name__ == '__main__':
     # Define the port
     port = 5000
 
-    # Open a ngrok tunnel to the Flask app
-    public_url = ngrok.connect(port)
-    print("*****************************************************************")
-    print(f"--> URL Pública: {public_url}")
-    print("--> Copia esta URL y pégala en tu navegador.")
-    print("*****************************************************************")
+    try:
+        # Open a ngrok tunnel to the Flask app
+        public_url = ngrok.connect(port)
+        print("*****************************************************************")
+        print(f"--> URL Pública: {public_url}")
+        print("--> Copia esta URL y pégala en tu navegador.")
+        print("*****************************************************************")
+    except Exception as e:
+        print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+        print(f"ERROR: Failed to start ngrok tunnel. This might be due to a missing or invalid authtoken.")
+        print(f"Please ensure your NGROK_AUTHTOKEN is set correctly as an environment variable or in a '.ngrok_authtoken' file.")
+        print(f"Ngrok error: {e}")
+        print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+        exit()
+
 
     # Run the Flask app without the reloader for stability with ngrok
     app.run(port=port, use_reloader=False)


### PR DESCRIPTION
This commit enhances the ngrok authtoken retrieval mechanism by adding specific support for Google Colab environments.

The application now attempts to find the `NGROK_AUTHTOKEN` in the following order:
1.  **Google Colab Secrets:** If the application is running in a Colab environment, it will first try to fetch the token using `google.colab.userdata.get('NGROK_AUTHTOKEN')`.
2.  **Environment Variable:** If the token is not found in Colab secrets or the app is not in Colab, it will check for the `NGROK_AUTHTOKEN` environment variable.
3.  **File Fallback:** If both of the above methods fail, it will look for the token in the `.ngrok_authtoken` file.

This change makes the application more robust and user-friendly, especially for users running it within Google Colab, while maintaining compatibility with other environments.