### PR TITLE
feat: Use google.colab.userdata for Hugging Face token

### DIFF
--- a/.Hugging_Token
+++ b/.Hugging_Token
@@ -1,1 +1,0 @@
-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

--- a/app.py
+++ b/app.py
@@ -168,11 +168,9 @@ if __name__ == "__main__":
         os.makedirs(AUDIO_LIBRARY_PATH)
     if not HF_TOKEN:
         print("\n" + "="*80)
-        print("AVISO: El token de Hugging Face no se ha encontrado.")
+        print("AVISO: El token de Hugging Face (HF_TOKEN) no se ha encontrado en los Secrets de Google Colab.")
         print("La diarización de hablantes no funcionará.")
-        print("Para solucionarlo, puedes:")
-        print("  a) Crear un archivo llamado '.Hugging_Token' en la raíz del proyecto y pegar tu token dentro.")
-        print("  b) O bien, configurar la variable de entorno HF_TOKEN.")
+        print("Para solucionarlo, ve al panel de 'Secrets' (icono de la llave 🔑 a la izquierda) y crea un nuevo secreto con el nombre 'HF_TOKEN' y tu token como valor.")
         print("\nRecuerda aceptar los términos de los modelos en Hugging Face para que la diarización funcione:")
         print("- pyannote/speaker-diarization-3.1")
         print("- pyannote/segmentation-3.0")

--- a/src/audio_processing.py
+++ b/src/audio_processing.py
@@ -3,6 +3,7 @@ import torch
 import os
 import gradio as gr
 from datetime import timedelta
+from google.colab import userdata
 
 # --- 1. CONFIGURACIÓN ---
 
@@ -10,19 +11,13 @@ DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 COMPUTE_TYPE = "float16" if torch.cuda.is_available() else "int8"
 
 def get_hf_token():
-    """Lee el token de Hugging Face desde el archivo .Hugging_Token o la variable de entorno."""
-    token_path = ".Hugging_Token"
-    # Primero, intenta leer desde el archivo
-    if os.path.exists(token_path):
-        with open(token_path, "r") as f:
-            token = f.read().strip()
-        if token:
-            # Establecer la variable de entorno para que otros módulos puedan usarla si es necesario
-            os.environ['HF_TOKEN'] = token
-            return token
-
-    # Si el archivo no existe o está vacío, intenta obtenerla de la variable de entorno
-    token = os.environ.get("HF_TOKEN")
+    """
+    Obtiene el token de Hugging Face desde los 'Secrets' de Google Colab.
+    Este script está diseñado para funcionar exclusivamente en Google Colab.
+    """
+    token = userdata.get('HF_TOKEN')
+    if not token:
+        print("Advertencia: No se encontró el secreto 'HF_TOKEN' en Google Colab. La diarización fallará.")
     return token
 
 HF_TOKEN = get_hf_token()


### PR DESCRIPTION
Refactors the application to use `google.colab.userdata` to securely fetch the Hugging Face API token. This makes the application specific to the Google Colab environment as per the user's request.

This change resolves the security issue of storing the token in a file, which caused it to be revoked by Hugging Face.

Changes include:
- Modified `src/audio_processing.py` to import `google.colab.userdata` and use `userdata.get('HF_TOKEN')`.
- Updated the startup message in `app.py` to provide clear instructions for creating a secret in Google Colab.
- Deleted the obsolete `.Hugging_Token` file from the repository.